### PR TITLE
Add missing TTS stop error message

### DIFF
--- a/src/bot/commands/tts/stop.rs
+++ b/src/bot/commands/tts/stop.rs
@@ -60,7 +60,7 @@ pub async fn stop(ctx: bot::Context<'_>) -> Result<(), bot::Error> {
             CreateReply::default().embed(
                 CreateEmbed::new()
                     .title("Error")
-                    .description("")
+                    .description("Solo el autor original o un usuario con el permiso de prioridad puede detener la reproducción.")
                     .color(0x00FF_0000),
             ),
         )


### PR DESCRIPTION
## Summary
- fill missing error message when unauthorized user stops TTS playback

## Testing
- `cargo test` *(fails: Submodule update failed. Run: git submodule update --init --recursive)*

------
https://chatgpt.com/codex/tasks/task_e_6897cacfd1a08321b9c29d16b18dbf08